### PR TITLE
Fix container_runtime and trusted_registry policy references when empty

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -13,8 +13,11 @@ resource "intersight_kubernetes_cluster_profile" "this" {
   cluster_ip_pools {
     moid = var.ip_pool_moid
   }
-  container_runtime_config {
-    moid = var.runtime_policy_moid
+  dynamic "container_runtime_config" {
+    for_each = var.runtime_policy_moid == "" ? [] : [var.runtime_policy_moid]
+    content {
+      moid = container_runtime_config.value
+    }
   }
   management_config {
     load_balancer_count = var.load_balancer
@@ -23,8 +26,11 @@ resource "intersight_kubernetes_cluster_profile" "this" {
     ]
     ssh_user = var.ssh_user
   }
-  trusted_registries {
-    moid = var.trusted_registry_policy_moid
+  dynamic "trusted_registries" {
+    for_each = var.trusted_registry_policy_moid == "" ? [] : [var.trusted_registry_policy_moid]
+    content {
+      moid = trusted_registries.value
+    }
   }
   net_config {
     moid = var.net_config_moid


### PR DESCRIPTION
Currently when you don't want to specify container_runtime and/or trusted_registry policy references on a cluster profile, an empty policy reference is created which leads to a change on every apply:

```
~ resource "intersight_kubernetes_cluster_profile" "this" {
...
      ~ trusted_registries           = [
          + {
              + additional_properties = null
              + class_id              = "mo.MoRef"
              + moid                  = ""
              + object_type           = null
              + selector              = null
            },
        ]
```

This change uses a dynamic block to avoid creating these empty references when runtime_policy_moid or trusted_registry_policy_moid are "".