### PR TITLE
Fix defaults for optional variables

### DIFF
--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -33,16 +33,19 @@ variable "wait_for_completion" {
   type        = bool
   default     = false
   description = "Wait for cluster completion true/false"
+  nullable    = false
 }
 variable "runtime_policy_moid" {
   type        = string
   description = "MOID for the Runtime Policy that is being consumed."
   default     = ""
+  nullable    = false
 }
 variable "trusted_registry_policy_moid" {
   type        = string
   description = "MOID for the Trusted Registry Policy that is being consumed."
   default     = ""
+  nullable    = false
 }
 
 variable "net_config_moid" {
@@ -60,6 +63,7 @@ variable "action" {
   type        = string
   description = "Action for cluster. i.e 'Deploy' 'Unassign'"
   default     = "Unassign"
+  nullable    = false
 }
 
 

--- a/modules/cluster_addon_profile/variables.tf
+++ b/modules/cluster_addon_profile/variables.tf
@@ -22,6 +22,7 @@ variable "cluster_moid" {
   type        = string
   description = "MOID of the cluster to be associated with this cluster addon profile."
   default     = ""
+  nullable    = false
 }
 variable "org_name" {
   type        = string

--- a/modules/infra_provider/variables.tf
+++ b/modules/infra_provider/variables.tf
@@ -6,21 +6,25 @@ variable "description" {
   type        = string
   default     = ""
   description = "Description to be used to describe the infrastructure provider policy"
+  nullable    = false
 }
 variable "instance_type_moid" {
   type        = string
   description = "MOID of the Instance type mapped to this provider"
   default     = ""
+  nullable    = false
 }
 variable "node_group_moid" {
   type        = string
   description = "MOID of the Node Group mapped to this provider"
   default     = ""
+  nullable    = false
 }
 variable "infra_config_policy_moid" {
   type        = string
   description = "MOID of the Infra Config Policy mapped to this provider"
   default     = ""
+  nullable    = false
 }
 variable "tags" {
   type        = list(map(string))

--- a/modules/ip_pool/variables.tf
+++ b/modules/ip_pool/variables.tf
@@ -6,6 +6,7 @@ variable "description" {
   type        = string
   default     = ""
   description = "Description to be used to describe the IP Pool Policy."
+  nullable    = false
 }
 variable "name" {
   type        = string
@@ -35,6 +36,7 @@ variable "secondary_dns" {
   type        = string
   description = "Secondary DNS Server for this pool."
   default     = ""
+  nullable    = false
 }
 
 variable "tags" {

--- a/modules/k8s_network/variables.tf
+++ b/modules/k8s_network/variables.tf
@@ -15,16 +15,19 @@ variable "pod_cidr" {
   type        = string
   description = "Pod CIDR Block to be used to assign POD IP Addresses."
   default     = "100.65.0.0/16"
+  nullable    = false
 }
 variable "service_cidr" {
   type        = string
   description = "Service CIDR Block used to assign cluster service IP addresses."
   default     = "100.64.0.0/24"
+  nullable    = false
 }
 variable "cni" {
   type        = string
   description = "Supported CNI type. Currently we only support Calico.* Calico - Calico CNI plugin as described in https://github.com/projectcalico/cni-plugin."
   default     = "Calico"
+  nullable    = false
 }
 
 variable "tags" {

--- a/modules/k8s_sysconfig/variables.tf
+++ b/modules/k8s_sysconfig/variables.tf
@@ -6,6 +6,7 @@ variable "description" {
   type        = string
   default     = ""
   description = "Description to be used to describe the K8s sysconfig profile."
+  nullable    = false
 }
 variable "policy_name" {
   type        = string

--- a/modules/node_profile/variables.tf
+++ b/modules/node_profile/variables.tf
@@ -6,16 +6,19 @@ variable "description" {
   type        = string
   description = "Descripton of the Node Profile."
   default     = ""
+  nullable    = false
 }
 variable "action" {
   default     = "No-op"
   description = "User Initiated action.  Options are {{Delete|Deploy|Ready|No-op|Unassign}."
   type        = string
+  nullable    = false
 }
 variable "profile_type" {
   type        = string
   description = "Type of profile to be created. i.e Master or Worker"
   default     = ""
+  nullable    = false
 }
 variable "min_size" {
   type        = number

--- a/modules/runtime_policy/variables.tf
+++ b/modules/runtime_policy/variables.tf
@@ -10,11 +10,13 @@ variable "description" {
   type        = string
   default     = ""
   description = "Description to be used to describe the addon policy"
+  nullable    = false
 }
 variable "docker_bridge_cidr" {
   type        = string
   default     = ""
   description = "Docker Bridge CIDR network to be specified."
+  nullable    = false
 }
 variable "proxy_http_hostname" {
   type        = string
@@ -24,21 +26,25 @@ variable "proxy_http_password" {
   type        = string
   default     = ""
   description = "The password for the HTTP Proxy."
+  nullable    = false
 }
 variable "proxy_http_username" {
   type        = string
   default     = ""
   description = "The username for the HTTP Proxy."
+  nullable    = false
 }
 variable "proxy_http_port" {
   type        = number
   default     = 8080
   description = "The HTTP Proxy port number.The port number of the HTTP proxy must be between 1 and 65535, inclusive."
+  nullable    = false
 }
 variable "proxy_http_protocol" {
   type        = string
   default     = "http"
   description = " Protocol to use for the HTTPS Proxy."
+  nullable    = false
 }
 variable "proxy_https_hostname" {
   type        = string
@@ -48,26 +54,31 @@ variable "proxy_https_password" {
   type        = string
   default     = ""
   description = "The password for the HTTPS Proxy."
+  nullable    = false
 }
 variable "proxy_https_username" {
   type        = string
   default     = ""
   description = "The username for the HTTPS Proxy."
+  nullable    = false
 }
 variable "proxy_https_port" {
   type        = number
   default     = 8443
   description = "The HTTPS Proxy port number.The port number of the HTTPS proxy must be between 1 and 65535, inclusive."
+  nullable    = false
 }
 variable "proxy_https_protocol" {
   type        = string
   default     = "https"
   description = " Protocol to use for the HTTPS Proxy."
+  nullable    = false
 }
 variable "docker_no_proxy" {
   type        = list(string)
   default     = []
   description = "Networks excluded from the proxy."
+  nullable    = false
 }
 variable "tags" {
   type        = list(map(string))

--- a/modules/trusted_registry/variables.tf
+++ b/modules/trusted_registry/variables.tf
@@ -6,6 +6,7 @@ variable "description" {
   type        = string
   default     = ""
   description = "Description to be used to describe the trusted registry profile."
+  nullable    = false
 }
 
 variable "policy_name" {
@@ -17,11 +18,13 @@ variable "root_ca_registries" {
   type        = list(string)
   description = "List of root CA certificates."
   default     = []
+  nullable    = false
 }
 variable "unsigned_registries" {
   type        = list(string)
   description = "List of unsigned registries to be supported."
   default     = []
+  nullable    = false
 }
 variable "tags" {
   type        = list(map(string))

--- a/modules/version/variables.tf
+++ b/modules/version/variables.tf
@@ -14,6 +14,7 @@ variable "description" {
   type        = string
   default     = ""
   description = "Description to be used to describe the k8s version profile."
+  nullable    = false
 }
 variable "tags" {
   type        = list(map(string))

--- a/modules/worker_profile/variables.tf
+++ b/modules/worker_profile/variables.tf
@@ -11,21 +11,25 @@ variable "cpu" {
   type        = number
   description = "Number of CPU allocated to the virtual machine."
   default     = 4
+  nullable    = false
 }
 variable "memory" {
   type        = number
   description = "Amount of memory assigned to the virtual machine in MiB."
   default     = 16384
+  nullable    = false
 }
 variable "disk_size" {
   type        = number
   description = "Amount of disk to be assigned to the virtual machine in GiB."
   default     = 40
+  nullable    = false
 }
 variable "description" {
   type        = string
   default     = ""
   description = "Description to be used to describe the worker profile."
+  nullable    = false
 }
 variable "tags" {
   type    = list(map(string))


### PR DESCRIPTION
Currently when a child module variable has a default, it is not getting applied when using the top-level module. 

This is because the top-level module uses optional attributes that are `null` when not specified by the user:
```
variable "k8s_network" {
  type = object({
    use_existing = bool
    name         = optional(string)
    pod_cidr     = optional(string)
    service_cidr = optional(string)
    cni          = optional(string)
  })
}
```

In the child module, the default is not then applied because `null` is a valid value (see https://www.terraform.io/language/values/variables#disallowing-null-input-values):
```
variable "service_cidr" {
  type        = string
  description = "Service CIDR Block used to assign cluster service IP addresses."
  default     = "100.64.0.0/24"
}
```

This ultimately results in changes being applied on every apply:
```
  # module.cg-tf-mod-test-deleteme.module.k8s_network[0].intersight_kubernetes_network_policy.this will be updated in-place
  ~ resource "intersight_kubernetes_network_policy" "this" {
...
      - pod_network_cidr      = "192.168.0.0/16" -> null
      - service_cidr          = "10.96.0.0/12" -> null
...
        # (17 unchanged attributes hidden)
    }
```

This change adds nullable=false to all child module variables that have a default, forcing the default to be used when the input is `null`