### PR TITLE
Add ending IP address for IP pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ module "terraform-intersight-iks" {
     name                = "10-239-21-0"
     # ip_starting_address = "10.239.21.220"
     # ip_pool_size        = "20"
+    # ip_ending_address   = "10.239.21.239"
     # ip_netmask          = "255.255.255.0"
     # ip_gateway          = "10.239.21.1"
     # dns_servers         = ["10.101.128.15","10.101.128.16"]
@@ -268,7 +269,7 @@ variable "tags" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers
@@ -281,21 +282,21 @@ variable "tags" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_addons"></a> [addons](#module\_addons) | terraform-cisco-modules/iks/intersight//modules/addon_policy | n/a |
-| <a name="module_cluster_addon_profile"></a> [cluster\_addon\_profile](#module\_cluster\_addon\_profile) | terraform-cisco-modules/iks/intersight//modules/cluster_addon_profile | n/a |
-| <a name="module_cluster_profile"></a> [cluster\_profile](#module\_cluster\_profile) | terraform-cisco-modules/iks/intersight//modules/cluster | n/a |
-| <a name="module_control_profile"></a> [control\_profile](#module\_control\_profile) | terraform-cisco-modules/iks/intersight//modules/node_profile | n/a |
-| <a name="module_control_provider"></a> [control\_provider](#module\_control\_provider) | terraform-cisco-modules/iks/intersight//modules/infra_provider | n/a |
-| <a name="module_infra_config_policy"></a> [infra\_config\_policy](#module\_infra\_config\_policy) | terraform-cisco-modules/iks/intersight//modules/infra_config_policy | n/a |
-| <a name="module_instance_type"></a> [instance\_type](#module\_instance\_type) | terraform-cisco-modules/iks/intersight//modules/worker_profile | n/a |
-| <a name="module_ip_pool_policy"></a> [ip\_pool\_policy](#module\_ip\_pool\_policy) | terraform-cisco-modules/iks/intersight//modules/ip_pool | n/a |
-| <a name="module_k8s_network"></a> [k8s\_network](#module\_k8s\_network) | terraform-cisco-modules/iks/intersight//modules/k8s_network | n/a |
-| <a name="module_k8s_sysconfig"></a> [k8s\_sysconfig](#module\_k8s\_sysconfig) | terraform-cisco-modules/iks/intersight//modules/k8s_sysconfig | n/a |
-| <a name="module_k8s_version"></a> [k8s\_version](#module\_k8s\_version) | terraform-cisco-modules/iks/intersight//modules/version | n/a |
-| <a name="module_runtime_policy"></a> [runtime\_policy](#module\_runtime\_policy) | terraform-cisco-modules/iks/intersight//modules/runtime_policy | n/a |
-| <a name="module_trusted_registry"></a> [trusted\_registry](#module\_trusted\_registry) | terraform-cisco-modules/iks/intersight//modules/trusted_registry | n/a |
-| <a name="module_worker_profile"></a> [worker\_profile](#module\_worker\_profile) | terraform-cisco-modules/iks/intersight//modules/node_profile | n/a |
-| <a name="module_worker_provider"></a> [worker\_provider](#module\_worker\_provider) | terraform-cisco-modules/iks/intersight//modules/infra_provider | n/a |
+| <a name="module_addons"></a> [addons](#module\_addons) | ./modules/addon_policy | n/a |
+| <a name="module_cluster_addon_profile"></a> [cluster\_addon\_profile](#module\_cluster\_addon\_profile) | ./modules/cluster_addon_profile | n/a |
+| <a name="module_cluster_profile"></a> [cluster\_profile](#module\_cluster\_profile) | ./modules/cluster | n/a |
+| <a name="module_control_profile"></a> [control\_profile](#module\_control\_profile) | ./modules/node_profile | n/a |
+| <a name="module_control_provider"></a> [control\_provider](#module\_control\_provider) | ./modules/infra_provider | n/a |
+| <a name="module_infra_config_policy"></a> [infra\_config\_policy](#module\_infra\_config\_policy) | ./modules/infra_config_policy | n/a |
+| <a name="module_instance_type"></a> [instance\_type](#module\_instance\_type) | ./modules/worker_profile | n/a |
+| <a name="module_ip_pool_policy"></a> [ip\_pool\_policy](#module\_ip\_pool\_policy) | ./modules/ip_pool | n/a |
+| <a name="module_k8s_network"></a> [k8s\_network](#module\_k8s\_network) | ./modules/k8s_network | n/a |
+| <a name="module_k8s_sysconfig"></a> [k8s\_sysconfig](#module\_k8s\_sysconfig) | ./modules/k8s_sysconfig | n/a |
+| <a name="module_k8s_version"></a> [k8s\_version](#module\_k8s\_version) | ./modules/version | n/a |
+| <a name="module_runtime_policy"></a> [runtime\_policy](#module\_runtime\_policy) | ./modules/runtime_policy | n/a |
+| <a name="module_trusted_registry"></a> [trusted\_registry](#module\_trusted\_registry) | ./modules/trusted_registry | n/a |
+| <a name="module_worker_profile"></a> [worker\_profile](#module\_worker\_profile) | ./modules/node_profile | n/a |
+| <a name="module_worker_provider"></a> [worker\_provider](#module\_worker\_provider) | ./modules/infra_provider | n/a |
 
 ## Resources
 
@@ -319,7 +320,7 @@ variable "tags" {
 | <a name="input_infraConfigPolicy"></a> [infraConfigPolicy](#input\_infraConfigPolicy) | n/a | <pre>object({<br>    use_existing       = bool<br>    platformType       = optional(string)<br>    targetName         = optional(string)<br>    policyName         = string<br>    description        = optional(string)<br>    interfaces         = optional(list(string))<br>    diskMode           = optional(string)<br>    vcTargetName       = optional(string)<br>    vcClusterName      = optional(string)<br>    vcDatastoreName    = optional(string)<br>    vcResourcePoolName = optional(string)<br>    vcPassword         = optional(string)<br>  })</pre> | n/a | yes |
 | <a name="input_infra_config_policy_name"></a> [infra\_config\_policy\_name](#input\_infra\_config\_policy\_name) | Name of existing infra config policy (if it exists) to be used. | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | <pre>object({<br>    use_existing = bool<br>    name         = string<br>    cpu          = optional(number)<br>    memory       = optional(number)<br>    disk_size    = optional(number)<br>  })</pre> | n/a | yes |
-| <a name="input_ip_pool"></a> [ip\_pool](#input\_ip\_pool) | n/a | <pre>object({<br>    use_existing        = bool<br>    name                = string<br>    ip_starting_address = optional(string)<br>    ip_pool_size        = optional(string)<br>    ip_netmask          = optional(string)<br>    ip_gateway          = optional(string)<br>    dns_servers         = optional(list(string))<br>  })</pre> | n/a | yes |
+| <a name="input_ip_pool"></a> [ip\_pool](#input\_ip\_pool) | n/a | <pre>object({<br>    use_existing        = bool<br>    name                = string<br>    ip_starting_address = optional(string)<br>    ip_pool_size        = optional(string)<br>    ip_ending_address   = optional(string)<br>    ip_netmask          = optional(string)<br>    ip_gateway          = optional(string)<br>    dns_servers         = optional(list(string))<br>  })</pre> | n/a | yes |
 | <a name="input_k8s_network"></a> [k8s\_network](#input\_k8s\_network) | n/a | <pre>object({<br>    use_existing = bool<br>    name         = optional(string)<br>    pod_cidr     = optional(string)<br>    service_cidr = optional(string)<br>    cni          = optional(string)<br>  })</pre> | n/a | yes |
 | <a name="input_k8s_network_policy_name"></a> [k8s\_network\_policy\_name](#input\_k8s\_network\_policy\_name) | Name of existing K8s Network Policy (if it exists) to be used. | `string` | `""` | no |
 | <a name="input_organization"></a> [organization](#input\_organization) | Organization Name | `string` | `"default"` | no |

--- a/examples/addons/README.md
+++ b/examples/addons/README.md
@@ -67,7 +67,7 @@ Note that this example may create resources which are consumed for IKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.18 |
 
 ## Providers

--- a/examples/cluster_addon_profile/README.md
+++ b/examples/cluster_addon_profile/README.md
@@ -55,7 +55,7 @@ Note that this example may create resources which are consumed for IKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.18 |
 
 ## Providers

--- a/examples/complete_cluster_deployment/README.md
+++ b/examples/complete_cluster_deployment/README.md
@@ -188,7 +188,7 @@ module "iks_cluster" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.19 |
 
 ## Providers

--- a/examples/infra_config_policy/README.md
+++ b/examples/infra_config_policy/README.md
@@ -62,7 +62,7 @@ Note that this example may create resources which are consumed for IKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.18 |
 
 ## Providers

--- a/examples/ip_pool/README.md
+++ b/examples/ip_pool/README.md
@@ -43,7 +43,7 @@ Note that this example may create resources which are consumed for IKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.18 |
 
 ## Providers

--- a/examples/ip_pool/main.tf
+++ b/examples/ip_pool/main.tf
@@ -9,6 +9,7 @@ module "ip_pool_1-139-140-0" {
   name             = "test_139"
   starting_address = "10.139.140.200"
   pool_size        = "20"
+  ending_address   = "10.139.140.219"
   netmask          = "255.255.255.0"
   gateway          = "10.139.140.1"
   primary_dns      = "10.101.128.15"

--- a/examples/k8s_network/README.md
+++ b/examples/k8s_network/README.md
@@ -40,7 +40,7 @@ Note that this example may create resources which are consumed for IKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.18 |
 
 ## Providers

--- a/examples/k8s_sysconfig/README.md
+++ b/examples/k8s_sysconfig/README.md
@@ -40,7 +40,7 @@ Note that this example may create resources which are consumed for IKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.18 |
 
 ## Providers

--- a/examples/runtime_policy/README.md
+++ b/examples/runtime_policy/README.md
@@ -42,7 +42,7 @@ Note that this example may create resources which are consumed for IKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.18 |
 
 ## Providers

--- a/examples/trusted_registry/README.md
+++ b/examples/trusted_registry/README.md
@@ -40,7 +40,7 @@ Current supported Version is 1.18.12
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.18 |
 
 ## Providers

--- a/examples/version/README.md
+++ b/examples/version/README.md
@@ -41,7 +41,7 @@ Current supported Version is 1.18.12
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.21 |
 
 ## Providers

--- a/examples/worker_profile/README.md
+++ b/examples/worker_profile/README.md
@@ -40,7 +40,7 @@ Note that this example may create resources which are consumed for IKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | =1.0.18 |
 
 ## Providers

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ module "ip_pool_policy" {
   name             = var.ip_pool.name
   starting_address = var.ip_pool.ip_starting_address
   pool_size        = var.ip_pool.ip_pool_size
-  ending_address = var.ip_pool.ip_ending_address
+  ending_address   = var.ip_pool.ip_ending_address
   netmask          = var.ip_pool.ip_netmask
   gateway          = var.ip_pool.ip_gateway
   primary_dns      = var.ip_pool.dns_servers[0]

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ module "ip_pool_policy" {
   name             = var.ip_pool.name
   starting_address = var.ip_pool.ip_starting_address
   pool_size        = var.ip_pool.ip_pool_size
+  ending_address = var.ip_pool.ip_ending_address
   netmask          = var.ip_pool.ip_netmask
   gateway          = var.ip_pool.ip_gateway
   primary_dns      = var.ip_pool.dns_servers[0]

--- a/modules/addon_policy/README.md
+++ b/modules/addon_policy/README.md
@@ -23,7 +23,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -23,7 +23,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/cluster_addon_profile/README.md
+++ b/modules/cluster_addon_profile/README.md
@@ -24,7 +24,7 @@ Note that this example may create resources which are consumed for IKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/infra_config_policy/README.md
+++ b/modules/infra_config_policy/README.md
@@ -29,7 +29,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/infra_provider/README.md
+++ b/modules/infra_provider/README.md
@@ -31,7 +31,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/ip_pool/README.md
+++ b/modules/ip_pool/README.md
@@ -23,7 +23,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers
@@ -48,6 +48,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_description"></a> [description](#input\_description) | Description to be used to describe the IP Pool Policy. | `string` | `""` | no |
+| <a name="input_ending_address"></a> [ending\_address](#input\_ending\_address) | Ending IP Address you want for this pool. | `string` | `null` | no |
 | <a name="input_gateway"></a> [gateway](#input\_gateway) | Default gateway for this pool. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the IP Pool to be created. | `string` | n/a | yes |
 | <a name="input_netmask"></a> [netmask](#input\_netmask) | Subnet Mask for this pool. | `string` | n/a | yes |

--- a/modules/ip_pool/main.tf
+++ b/modules/ip_pool/main.tf
@@ -10,6 +10,7 @@ resource "intersight_ippool_pool" "this" {
   ip_v4_blocks {
     from = var.starting_address
     size = var.pool_size
+    to = var.ending_address
   }
   ip_v4_config {
     netmask       = var.netmask

--- a/modules/ip_pool/main.tf
+++ b/modules/ip_pool/main.tf
@@ -10,7 +10,7 @@ resource "intersight_ippool_pool" "this" {
   ip_v4_blocks {
     from = var.starting_address
     size = var.pool_size
-    to = var.ending_address
+    to   = var.ending_address
   }
   ip_v4_config {
     netmask       = var.netmask

--- a/modules/ip_pool/variables.tf
+++ b/modules/ip_pool/variables.tf
@@ -20,6 +20,11 @@ variable "pool_size" {
   type        = string
   description = "Number of IPs you want this pool to contain."
 }
+variable "ending_address" {
+  type        = string
+  description = "Ending IP Address you want for this pool."
+  default = null
+}
 variable "netmask" {
   type        = string
   description = "Subnet Mask for this pool."

--- a/modules/ip_pool/variables.tf
+++ b/modules/ip_pool/variables.tf
@@ -23,7 +23,7 @@ variable "pool_size" {
 variable "ending_address" {
   type        = string
   description = "Ending IP Address you want for this pool."
-  default = null
+  default     = null
 }
 variable "netmask" {
   type        = string

--- a/modules/k8s_network/README.md
+++ b/modules/k8s_network/README.md
@@ -26,7 +26,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/k8s_sysconfig/README.md
+++ b/modules/k8s_sysconfig/README.md
@@ -25,7 +25,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/node_profile/README.md
+++ b/modules/node_profile/README.md
@@ -26,7 +26,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/runtime_policy/README.md
+++ b/modules/runtime_policy/README.md
@@ -23,7 +23,7 @@ These resources are created:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/trusted_registry/README.md
+++ b/modules/trusted_registry/README.md
@@ -25,7 +25,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/version/README.md
+++ b/modules/version/README.md
@@ -30,7 +30,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/modules/worker_profile/README.md
+++ b/modules/worker_profile/README.md
@@ -24,7 +24,7 @@ These resources are created
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
 | <a name="requirement_intersight"></a> [intersight](#requirement\_intersight) | >=1.0.18 |
 
 ## Providers

--- a/variables.tf
+++ b/variables.tf
@@ -98,7 +98,7 @@ variable "ip_pool" {
     name                = string
     ip_starting_address = optional(string)
     ip_pool_size        = optional(string)
-    ip_ending_address = optional(string)
+    ip_ending_address   = optional(string)
     ip_netmask          = optional(string)
     ip_gateway          = optional(string)
     dns_servers         = optional(list(string))

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,7 @@ variable "ip_pool" {
     name                = string
     ip_starting_address = optional(string)
     ip_pool_size        = optional(string)
+    ip_ending_address = optional(string)
     ip_netmask          = optional(string)
     ip_gateway          = optional(string)
     dns_servers         = optional(list(string))


### PR DESCRIPTION
Add an (optional) ending IP for IP pools. This way when you specify starting IP, ending IP and pool size Terraform won't detect unnecessary changes on each apply. (see #98)