### PR TITLE
Do not set ssh_user

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -24,7 +24,6 @@ resource "intersight_kubernetes_cluster_profile" "this" {
     ssh_keys = [
       var.ssh_key
     ]
-    ssh_user = var.ssh_user
   }
   dynamic "trusted_registries" {
     for_each = var.trusted_registry_policy_moid == "" ? [] : [var.trusted_registry_policy_moid]


### PR DESCRIPTION
Do not set ssh_user on cluster resource as it is now read only in the provider