### PR TITLE
Update README.md

### DIFF
--- a/examples/complete_cluster_deployment/README.md
+++ b/examples/complete_cluster_deployment/README.md
@@ -97,7 +97,7 @@ module "iks_cluster" {
   versionPolicy = {
     useExisting    = false
     policyName     = "1.19.15"
-    iksVersionName = "1.19.15-iks.3"
+    versionName = "1.19.15-iks.3"
   }
 
   # Trusted Registry Policy (To create new change "use_existing" to 'false' and set "create_new' to 'true' uncomment variables and modify them to meet your needs.)


### PR DESCRIPTION
The module k8s_version in terraform-intersight-iks/main.tf seems to call var.versionPolicy.versionName.  So in this readme defining the version with iksVersionName would not allow terraform the find the moid of the desired versions.  Not sure if the problem is in this readme file or the module, but this changed seemed to work for my one use case.